### PR TITLE
Updated MexcAuthenticationProvider to skip header creation for unauthenticated requests

### DIFF
--- a/Mexc.Net/MexcAuthenticationProvider.cs
+++ b/Mexc.Net/MexcAuthenticationProvider.cs
@@ -1,5 +1,5 @@
-﻿using CryptoExchange.Net.Clients;
-using System.Text;
+﻿using System.Text;
+using CryptoExchange.Net.Clients;
 
 namespace Mexc.Net
 {
@@ -21,11 +21,11 @@ namespace Mexc.Net
             HttpMethodParameterPosition parameterPosition,
             RequestBodyFormat requestBodyFormat)
         {
-            headers ??= new Dictionary<string, string>();
-            headers.Add("X-MEXC-APIKEY", _credentials.Key);
-
             if (!auth)
                 return;
+
+            headers ??= new Dictionary<string, string>();
+            headers.Add("X-MEXC-APIKEY", _credentials.Key);
 
             IDictionary<string, object> parameters;
             if (parameterPosition == HttpMethodParameterPosition.InUri)


### PR DESCRIPTION
The following test failed on the second GetKLinesAsync() call:
```csharp
var client = new MexcRestClient(null, new TestLoggerFactory(), Options.Create<MexcRestOptions>(new()));
// Success
var successResponse = await client.SpotApi.ExchangeData.GetKlinesAsync("BTCUSDT", Mexc.Net.Enums.KlineInterval.OneMinute, limit: 2);

client.SetApiCredentials(new("x", "y"));
// Failed
var failedResponse= await client.SpotApi.ExchangeData.GetKlinesAsync("BTCUSDT", Mexc.Net.Enums.KlineInterval.OneMinute, limit: 2);
```

Error Message: `Error response: [ServerError] 700004: Mandatory parameter 'signature' was not sent, was empty/null, or malformed. , 99 bytes received in 256ms`

I noticed that the `X-MEXC-APIKEY` header was set even though authentication was not required for the request. My change fixes the error. **I hope that there was no specific reason that the key was set before the auth check.**