### PR TITLE
Added NextSettleTime to MexcFundingRateUpdate

### DIFF
--- a/Mexc.Net/Objects/Models/Futures/MexcFundingRateUpdate.cs
+++ b/Mexc.Net/Objects/Models/Futures/MexcFundingRateUpdate.cs
@@ -14,6 +14,11 @@ namespace Mexc.Net.Objects.Models.Futures
         /// ["<c>rate</c>"] Funding rate
         /// </summary>
         [JsonPropertyName("rate")]
-        public decimal FundingRate { get; set; }        
+        public decimal FundingRate { get; set; }
+        /// <summary>
+        /// ["<c>nextSettleTime</c>"] Next settlement time
+        /// </summary>
+        [JsonPropertyName("nextSettleTime")]
+        public DateTime NextSettleTime { get; set; }
     }
 }


### PR DESCRIPTION
Added missing `NextSettleTime` property to `MexcFundingRateUpdate`
(Docs: https://www.mexc.com/api-docs/futures/websocket-api#funding-rate)