### PR TITLE
Updated MexcWithdrawal and MexcUserAsset model

### DIFF
--- a/Mexc.Net.UnitTests/Endpoints/SpotApi/Account/GetUserAssets.txt
+++ b/Mexc.Net.UnitTests/Endpoints/SpotApi/Account/GetUserAssets.txt
@@ -15,7 +15,7 @@ true
           "network": "EOS",
           "withdrawEnable": false,
           "withdrawFee": "0.000100000000000000",
-          "withdrawIntegerMultiple": null,
+          "withdrawIntegerMultiple": "0.000001",
           "withdrawMax": "10000.000000000000000000",
           "withdrawMin": "0.001000000000000000",
           "sameAddress": false,

--- a/Mexc.Net.UnitTests/Endpoints/SpotApi/Account/GetWithdrawAddresses.txt
+++ b/Mexc.Net.UnitTests/Endpoints/SpotApi/Account/GetWithdrawAddresses.txt
@@ -6,6 +6,7 @@ true
         {
             "coin": "USDT",
             "network": "TRC20",
+            "netWork": "TRX",
             "address": "TArGWdTApuuZtiWMjupXqbZqQYsBTy126o",
             "addressTag": "test",
             "memo": null
@@ -13,6 +14,7 @@ true
         {
             "coin": "USDT",
             "network": "BEP20(BSC)",
+            "netWork": "BSC",
             "address": "0xa82898C70BeB5E1b1621fdA62fD17Ba27227BBC5",
             "addressTag": "usdt",
             "memo": null

--- a/Mexc.Net.UnitTests/Endpoints/SpotApi/Account/GetWithdrawHistory.txt
+++ b/Mexc.Net.UnitTests/Endpoints/SpotApi/Account/GetWithdrawHistory.txt
@@ -4,6 +4,7 @@ true
 [
   {
         "id": "bb17a2d452684f00a523c015d512a341",
+        "withdrawOrderId": "client-withdraw-123",
         "txId": null,
         "coin": "EOS",
         "network": "EOS",

--- a/Mexc.Net/Objects/Models/Spot/MexcUserAsset.cs
+++ b/Mexc.Net/Objects/Models/Spot/MexcUserAsset.cs
@@ -82,8 +82,8 @@ namespace Mexc.Net.Objects.Models.Spot
         /// <summary>
         /// ["<c>withdrawIntegerMultiple</c>"] Withdrawal multiple
         /// </summary>
-        [JsonPropertyName("withdrawIntegerMultiple")]
-        public int? WithdrawIntegerMultiple { get; set; }
+        [JsonPropertyName("withdrawIntegerMultiple"), JsonConverter(typeof(BigDecimalConverter))]
+        public decimal? WithdrawIntegerMultiple { get; set; }
         /// <summary>
         /// ["<c>withdrawMax</c>"] Max withdrawal
         /// </summary>

--- a/Mexc.Net/Objects/Models/Spot/MexcWithdrawAddress.cs
+++ b/Mexc.Net/Objects/Models/Spot/MexcWithdrawAddress.cs
@@ -17,6 +17,11 @@ namespace Mexc.Net.Objects.Models.Spot
         [JsonPropertyName("network")]
         public string Network { get; set; } = string.Empty;
         /// <summary>
+        /// ["<c>netWork</c>"] Exchange-native network code
+        /// </summary>
+        [JsonPropertyName("netWork")]
+        public string NetworkCode { get; set; } = string.Empty;
+        /// <summary>
         /// ["<c>address</c>"] Address
         /// </summary>
         [JsonPropertyName("address")]

--- a/Mexc.Net/Objects/Models/Spot/MexcWithdrawal.cs
+++ b/Mexc.Net/Objects/Models/Spot/MexcWithdrawal.cs
@@ -14,6 +14,11 @@ namespace Mexc.Net.Objects.Models.Spot
         [JsonPropertyName("id")]
         public string Id { get; set; } = string.Empty;
         /// <summary>
+        /// ["<c>withdrawOrderId</c>"] Client withdrawal order id
+        /// </summary>
+        [JsonPropertyName("withdrawOrderId")]
+        public string? WithdrawOrderId { get; set; }
+        /// <summary>
         /// ["<c>txId</c>"] Transaction id
         /// </summary>
         [JsonPropertyName("txId")]


### PR DESCRIPTION
- Updated `MexcUserAsset.WithdrawIntegerMultiple` type to `decimal?`
- Added `MexcWithdrawal.WithdrawOrderId` property
---
- Added the `NetworkCode` property to `MexcWithdrawAddress`.
Unfortunately, the existing `Network` property only returns the name of the network. But I need the code, which is also used by Mexc in other places.

Unfortunately, this isn't properly documented in the docs. However, the JSON result looks like this:
```json
{
    "data": [
        {
            "coin": "USDC",
            "network": "Avalanche C Chain(AVAX CCHAIN)",
            "address": "...",
            "addressTag": "",
            "memo": null,
            "chainNames": [
                "Avalanche C Chain(AVAX CCHAIN)"
            ],
            "chainDisplayName": "Avalanche C Chain(AVAX CCHAIN)",
            "netWork": "AVAX_CCHAIN"
        }
    ],
    "totalRecords": 1,
    "page": 1,
    "totalPageNum": 1
}
```